### PR TITLE
make new talk field label more clear to users

### DIFF
--- a/app/views/admin/lightning_talks/edit.haml
+++ b/app/views/admin/lightning_talks/edit.haml
@@ -5,7 +5,7 @@
         = message
   = form_for @lightning_talk, url: admin_lightning_talk_path(@lightning_talk), html: {class: "form-horizontal"} do |f|
     .form-group
-      = f.label :name, class: "control-label col-md-2"
+      = f.label :name, "Talk Topic", class: "control-label col-md-2"
       .col-md-9
         = f.text_field :name, class: "form-control"
 

--- a/app/views/admin/lightning_talks/new.html.haml
+++ b/app/views/admin/lightning_talks/new.html.haml
@@ -5,7 +5,7 @@
         = message
   = form_for @lightning_talk, url: admin_lightning_talks_path, html: {class: "form-horizontal"} do |f|
     .form-group
-      = f.label :name, class: "control-label col-md-2"
+      = f.label :name, "Talk Topic", class: "control-label col-md-2"
       .col-md-9
         = f.text_field :name, class: "form-control"
 

--- a/app/views/days/lightning_talks/new.html.haml
+++ b/app/views/days/lightning_talks/new.html.haml
@@ -4,7 +4,7 @@
     = @day.talk_date.readable_inspect
   = form_for ([@day, @lightning_talk]), html: {class: "form-horizontal"} do |f|
     .form-group
-      = f.label :name, class: "control-label col-md-2"
+      = f.label :name, "Talk Topic", class: "control-label col-md-2"
       .col-md-9
         = f.text_field :name, class: "form-control"
 

--- a/app/views/users/lightning_talks/_form.haml
+++ b/app/views/users/lightning_talks/_form.haml
@@ -5,7 +5,7 @@
         = message
   = form_for ([@user, @lightning_talk]), html: {class: "form-horizontal"} do |f|
     .form-group
-      = f.label :name, class: "control-label col-md-2"
+      = f.label :name, "Talk Topic", class: "control-label col-md-2"
       .col-md-9
         = f.text_field :name, class: "form-control"
     - if new_form

--- a/spec/features/admin_lightning_talk_management_spec.rb
+++ b/spec/features/admin_lightning_talk_management_spec.rb
@@ -33,7 +33,7 @@ feature 'Admin Lightning Talks' do
 
     click_on 'New Lightning Talk Admin'
 
-    fill_in 'Name', with: 'Another Test Talk'
+    fill_in 'Talk Topic', with: 'Another Test Talk'
     select @day.talk_date, from: "Day"
     click_on 'Create Lightning Talk'
 
@@ -50,7 +50,7 @@ feature 'Admin Lightning Talks' do
     expect(page).to have_content 'Test Talk'
     click_on 'Edit'
 
-    fill_in 'Name', with: 'Changed the words'
+    fill_in 'Talk Topic', with: 'Changed the words'
     select new_day.talk_date, from: "Day"
     click_on 'Update Lightning Talk'
 

--- a/spec/features/lightning_talk_management_spec.rb
+++ b/spec/features/lightning_talk_management_spec.rb
@@ -26,7 +26,7 @@ feature "creating lightning talks" do
     expect(page).to have_content "Sign Out"
     click_on "New Lightning Talk"
 
-    fill_in "Name", with: "How to dance"
+    fill_in "Talk Topic", with: "How to dance"
     select @day.talk_date, from: "Day"
 
     click_on "Create Lightning Talk"
@@ -44,7 +44,7 @@ feature "creating lightning talks" do
     click_on "Sign Up"
     expect(page).to have_content "New Lightning Talk For"
 
-    fill_in "Name", with: "How to play the fiddle"
+    fill_in "Talk Topic", with: "How to play the fiddle"
 
     click_on "Create Lightning Talk"
 


### PR DESCRIPTION
People keep titling their talks as their names, not talk names. I'll do something better next. 